### PR TITLE
(bug): update image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ undeploy: $(CONTROLLER_GEN) $(KUSTOMIZE) ## Undeploy controller from the K8s clu
 set-manifest-image:
 	$(info Updating kustomize image patch file for manager resource)
 	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./config/default/manager_image_patch.yaml
-	sed -i'' -e 's@image: projectsveltos.*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./manifest/mgmt_cluster_manifest.yaml
+	sed -i'' -e 's@image: .*@image: '"docker.io/${MANIFEST_IMG}:$(MANIFEST_TAG)"'@' ./manifest/mgmt_cluster_manifest.yaml
 
 set-manifest-pull-policy:
 	$(info Updating kustomize pull policy file for manager resource)

--- a/manifest/mgmt_cluster_manifest.yaml
+++ b/manifest/mgmt_cluster_manifest.yaml
@@ -28,7 +28,7 @@ spec:
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
`make manifests` target now correctly updates the image tag for the sveltos-agent when deployed in the management cluster

closes #295 