### PR TITLE
(feat) sveltos-agent compatibility check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bin/manager
 manager_image_patch.yaml-e
 manager_pull_policy.yaml-e
 mgmt_cluster_manifest.yaml-e
+manager_auth_proxy_patch.yaml-e
 
 version.txt
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,6 +79,7 @@ var (
 	webhookPort         int
 	syncPeriod          time.Duration
 	healthAddr          string
+	version             string
 )
 
 // Add RBAC for the authorized diagnostics endpoint.
@@ -143,8 +144,8 @@ func main() {
 
 	const intervalInSecond = 3
 	evaluation.InitializeManager(ctx, mgr.GetLogger(),
-		mgr.GetConfig(), mgr.GetClient(), clusterNamespace, clusterName, libsveltosv1beta1.ClusterType(clusterType),
-		intervalInSecond, doSendReports)
+		mgr.GetConfig(), mgr.GetClient(), clusterNamespace, clusterName, version,
+		libsveltosv1beta1.ClusterType(clusterType), intervalInSecond, doSendReports)
 
 	go startControllers(ctx, mgr, sendReports)
 	//+kubebuilder:scaffold:builder
@@ -201,6 +202,13 @@ func initFlags(fs *pflag.FlagSet) {
 		"cluster-type",
 		"",
 		"cluster type",
+	)
+
+	flag.StringVar(
+		&version,
+		"version",
+		"",
+		"indicates sveltos-agent version",
 	)
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -16,5 +16,6 @@ spec:
         - "--cluster-namespace="
         - "--cluster-name="
         - "--cluster-type="
+        - "--version=dev"
         - "--current-cluster=managed-cluster"
         - "--run-mode=do-not-send-reports"

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: docker.io/projectsveltos/sveltos-agent:main
+      - image: docker.io/projectsveltos/sveltos-agent:dev
         name: manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,16 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'

--- a/controllers/classifier_controller_test.go
+++ b/controllers/classifier_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Controllers: classifier controller", func() {
 		watcherCtx, cancel = context.WithCancel(context.Background())
 		evaluation.InitializeManager(watcherCtx,
 			textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))), testEnv.Config, testEnv.Client,
-			randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, 3, false)
+			randomString(), randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, 3, false)
 	})
 
 	AfterEach(func() {

--- a/controllers/eventsource_controller_test.go
+++ b/controllers/eventsource_controller_test.go
@@ -41,7 +41,8 @@ var _ = Describe("Controllers: eventSource controller", func() {
 	BeforeEach(func() {
 		watcherCtx, cancel = context.WithCancel(context.Background())
 		evaluation.InitializeManager(watcherCtx, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
-			testEnv.Config, testEnv.Client, randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, 3, false)
+			testEnv.Config, testEnv.Client, randomString(), randomString(), randomString(),
+			libsveltosv1beta1.ClusterTypeCapi, 3, false)
 	})
 
 	AfterEach(func() {

--- a/controllers/healthcheck_controller_test.go
+++ b/controllers/healthcheck_controller_test.go
@@ -40,7 +40,8 @@ var _ = Describe("Controllers: healthCheck controller", func() {
 	BeforeEach(func() {
 		watcherCtx, cancel = context.WithCancel(context.Background())
 		evaluation.InitializeManager(watcherCtx, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
-			testEnv.Config, testEnv.Client, randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, 3, false)
+			testEnv.Config, testEnv.Client, randomString(), randomString(), randomString(),
+			libsveltosv1beta1.ClusterTypeCapi, 3, false)
 	})
 
 	AfterEach(func() {

--- a/controllers/node_controller_test.go
+++ b/controllers/node_controller_test.go
@@ -86,7 +86,8 @@ var _ = Describe("Controllers: node controller", func() {
 		Expect(testEnv.Status().Update(watcherCtx, &currentNode)).To(Succeed())
 
 		evaluation.InitializeManager(watcherCtx, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
-			testEnv.Config, testEnv.Client, randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, 3, false)
+			testEnv.Config, testEnv.Client, randomString(), randomString(), randomString(),
+			libsveltosv1beta1.ClusterTypeCapi, 3, false)
 
 		reconciler := &controllers.NodeReconciler{
 			Client: testEnv.Client,

--- a/controllers/reloader_controller_test.go
+++ b/controllers/reloader_controller_test.go
@@ -45,7 +45,8 @@ var _ = Describe("Controllers: reloader controller", func() {
 	BeforeEach(func() {
 		watcherCtx, cancel = context.WithCancel(context.Background())
 		evaluation.InitializeManager(watcherCtx, textlogger.NewLogger(textlogger.NewConfig(textlogger.Verbosity(1))),
-			testEnv.Config, testEnv.Client, randomString(), randomString(), libsveltosv1beta1.ClusterTypeCapi, 3, false)
+			testEnv.Config, testEnv.Client, randomString(), randomString(), randomString(),
+			libsveltosv1beta1.ClusterTypeCapi, 3, false)
 	})
 
 	AfterEach(func() {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -40,6 +40,7 @@ const (
 	deleteRequeueAfter = 20 * time.Second
 )
 
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups=lib.projectsveltos.io,resources=debuggingconfigurations,verbs=get;list;watch
 //+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;impersonate

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f
+	github.com/projectsveltos/libsveltos v0.37.1-0.20240903133242-23de3048ef2a
 	github.com/spf13/pflag v1.0.5
 	github.com/yuin/gopher-lua v1.1.1
 	golang.org/x/text v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f h1:eeVqeBF8YJsf42bMhxQlHyQuV5GYBc1UrV9DMiAh588=
-github.com/projectsveltos/libsveltos v0.37.1-0.20240831173303-3b450159d14f/go.mod h1:YZQWtvZUDfg2VbjrPEGVQZa/yxq0n+KMV58iro7L5yg=
+github.com/projectsveltos/libsveltos v0.37.1-0.20240903133242-23de3048ef2a h1:ydhJD/+j1iT/qwsS/dInlqSJ+Zz9VkW0XUmEP6Rk2js=
+github.com/projectsveltos/libsveltos v0.37.1-0.20240903133242-23de3048ef2a/go.mod h1:YZQWtvZUDfg2VbjrPEGVQZa/yxq0n+KMV58iro7L5yg=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -15,6 +15,16 @@ metadata:
   name: sveltos-agent-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - '*'
   resources:
   - '*'
@@ -165,11 +175,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
+        - --version=dev
         - --current-cluster=managed-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/manifest/mgmt_cluster_manifest.yaml
+++ b/manifest/mgmt_cluster_manifest.yaml
@@ -24,11 +24,12 @@ spec:
         - --cluster-namespace=
         - --cluster-name=
         - --cluster-type=
+        - --version=dev
         - --current-cluster=management-cluster
         - --run-mode=do-not-send-reports
         command:
         - /manager
-        image: docker.io/projectsveltos/sveltos-agent:main
+        image: docker.io/projectsveltos/sveltos-agent:dev
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
Sveltos-agent evaluates classifier, healthCheck, eventSource, and reloader instances within managed clusters. Other Sveltos microservices in the management cluster consume these evaluation results. During upgrades, management cluster services should pause fetching sveltos-agent evaluation results until the sveltos-agent version aligns with the versions of the Sveltos microservices in the management cluster.

Sveltos-agent creates a ConfigMap in each managed cluster to store its version. Sveltos services in the management cluster then reference this ConfigMap to verify version compatibility.

This compatibility check is especially important when Sveltos CRD versions change after upgrades. For example, if we transition from v1alpha1 to v1beta1, without this check, Sveltos microservices might attempt to fetch v1beta1 instances while sveltos-agent and the CRDs in the managed cluster are still on the older version.

This PR makes sure that sveltos-agent stores its current version after successfully evaluating classifiers, healthChecks, eventSources and reloaders once.