### PR TITLE
(Bug) recover when token expires

### DIFF
--- a/pkg/evaluation/eventsource_evaluation.go
+++ b/pkg/evaluation/eventsource_evaluation.go
@@ -59,44 +59,50 @@ func (m *manager) evaluateEventSources(ctx context.Context, wg *sync.WaitGroup) 
 	var once sync.Once
 
 	for {
-		// Sleep before next evaluation
-		time.Sleep(m.interval)
+		select {
+		case <-ctx.Done():
+			m.log.V(logs.LogInfo).Info("Context canceled. Exiting evaluation.")
+			return // Exit the goroutine
+		default:
+			// Sleep before next evaluation
+			time.Sleep(m.interval)
 
-		m.log.V(logs.LogDebug).Info("Evaluating EventSources")
-		m.mu.Lock()
-		// Copy queue content. That is only operation that
-		// needs to be done in a mutex protect section
-		jobQueueCopy := make([]string, len(m.eventSourceJobQueue))
-		i := 0
-		for k := range m.eventSourceJobQueue {
-			jobQueueCopy[i] = k
-			i++
-		}
-		// Reset current queue
-		m.eventSourceJobQueue = make(map[string]bool)
-		m.mu.Unlock()
-
-		failedEvaluations := make([]string, 0)
-
-		for i := range jobQueueCopy {
-			m.log.V(logs.LogDebug).Info(fmt.Sprintf("Evaluating EventSource %s", jobQueueCopy[i]))
-			err := m.evaluateEventSourceInstance(ctx, jobQueueCopy[i])
-			if err != nil {
-				m.log.V(logs.LogInfo).Error(err,
-					fmt.Sprintf("failed to evaluate EventSource %s", jobQueueCopy[i]))
-				failedEvaluations = append(failedEvaluations, jobQueueCopy[i])
+			m.log.V(logs.LogDebug).Info("Evaluating EventSources")
+			m.mu.Lock()
+			// Copy queue content. That is only operation that
+			// needs to be done in a mutex protect section
+			jobQueueCopy := make([]string, len(m.eventSourceJobQueue))
+			i := 0
+			for k := range m.eventSourceJobQueue {
+				jobQueueCopy[i] = k
+				i++
 			}
-		}
+			// Reset current queue
+			m.eventSourceJobQueue = make(map[string]bool)
+			m.mu.Unlock()
 
-		// Re-queue all EventSources whose evaluation failed
-		for i := range failedEvaluations {
-			m.log.V(logs.LogDebug).Info(fmt.Sprintf("requeuing EventSource %s for evaluation", failedEvaluations[i]))
-			m.EvaluateEventSource(failedEvaluations[i])
-		}
+			failedEvaluations := make([]string, 0)
 
-		once.Do(func() {
-			wg.Done()
-		})
+			for i := range jobQueueCopy {
+				m.log.V(logs.LogDebug).Info(fmt.Sprintf("Evaluating EventSource %s", jobQueueCopy[i]))
+				err := m.evaluateEventSourceInstance(ctx, jobQueueCopy[i])
+				if err != nil {
+					m.log.V(logs.LogInfo).Error(err,
+						fmt.Sprintf("failed to evaluate EventSource %s", jobQueueCopy[i]))
+					failedEvaluations = append(failedEvaluations, jobQueueCopy[i])
+				}
+			}
+
+			// Re-queue all EventSources whose evaluation failed
+			for i := range failedEvaluations {
+				m.log.V(logs.LogDebug).Info(fmt.Sprintf("requeuing EventSource %s for evaluation", failedEvaluations[i]))
+				m.EvaluateEventSource(failedEvaluations[i])
+			}
+
+			once.Do(func() {
+				wg.Done()
+			})
+		}
 	}
 }
 

--- a/pkg/evaluation/healthcheck_evaluation.go
+++ b/pkg/evaluation/healthcheck_evaluation.go
@@ -57,44 +57,50 @@ func (m *manager) evaluateHealthChecks(ctx context.Context, wg *sync.WaitGroup) 
 	var once sync.Once
 
 	for {
-		// Sleep before next evaluation
-		time.Sleep(m.interval)
+		select {
+		case <-ctx.Done():
+			m.log.V(logs.LogInfo).Info("Context canceled. Exiting evaluation.")
+			return // Exit the goroutine
+		default:
+			// Sleep before next evaluation
+			time.Sleep(m.interval)
 
-		m.log.V(logs.LogDebug).Info("Evaluating HealthChecks")
-		m.mu.Lock()
-		// Copy queue content. That is only operation that
-		// needs to be done in a mutex protect section
-		jobQueueCopy := make([]string, len(m.healthCheckJobQueue))
-		i := 0
-		for k := range m.healthCheckJobQueue {
-			jobQueueCopy[i] = k
-			i++
-		}
-		// Reset current queue
-		m.healthCheckJobQueue = make(map[string]bool)
-		m.mu.Unlock()
-
-		failedEvaluations := make([]string, 0)
-
-		for i := range jobQueueCopy {
-			m.log.V(logs.LogDebug).Info(fmt.Sprintf("Evaluating HealthCheck %s", jobQueueCopy[i]))
-			err := m.evaluateHealthCheckInstance(ctx, jobQueueCopy[i])
-			if err != nil {
-				m.log.V(logs.LogInfo).Error(err,
-					fmt.Sprintf("failed to evaluate HealthCheck %s", jobQueueCopy[i]))
-				failedEvaluations = append(failedEvaluations, jobQueueCopy[i])
+			m.log.V(logs.LogDebug).Info("Evaluating HealthChecks")
+			m.mu.Lock()
+			// Copy queue content. That is only operation that
+			// needs to be done in a mutex protect section
+			jobQueueCopy := make([]string, len(m.healthCheckJobQueue))
+			i := 0
+			for k := range m.healthCheckJobQueue {
+				jobQueueCopy[i] = k
+				i++
 			}
-		}
+			// Reset current queue
+			m.healthCheckJobQueue = make(map[string]bool)
+			m.mu.Unlock()
 
-		// Re-queue all HealthChecks whose evaluation failed
-		for i := range failedEvaluations {
-			m.log.V(logs.LogDebug).Info(fmt.Sprintf("requeuing HealthCheck %s for evaluation", failedEvaluations[i]))
-			m.EvaluateHealthCheck(failedEvaluations[i])
-		}
+			failedEvaluations := make([]string, 0)
 
-		once.Do(func() {
-			wg.Done()
-		})
+			for i := range jobQueueCopy {
+				m.log.V(logs.LogDebug).Info(fmt.Sprintf("Evaluating HealthCheck %s", jobQueueCopy[i]))
+				err := m.evaluateHealthCheckInstance(ctx, jobQueueCopy[i])
+				if err != nil {
+					m.log.V(logs.LogInfo).Error(err,
+						fmt.Sprintf("failed to evaluate HealthCheck %s", jobQueueCopy[i]))
+					failedEvaluations = append(failedEvaluations, jobQueueCopy[i])
+				}
+			}
+
+			// Re-queue all HealthChecks whose evaluation failed
+			for i := range failedEvaluations {
+				m.log.V(logs.LogDebug).Info(fmt.Sprintf("requeuing HealthCheck %s for evaluation", failedEvaluations[i]))
+				m.EvaluateHealthCheck(failedEvaluations[i])
+			}
+
+			once.Do(func() {
+				wg.Done()
+			})
+		}
 	}
 }
 

--- a/pkg/evaluation/manager.go
+++ b/pkg/evaluation/manager.go
@@ -156,10 +156,18 @@ func InitializeManager(ctx context.Context, l logr.Logger, config *rest.Config, 
 // GetManager returns the manager instance implementing the ClassifierInterface.
 // Returns nil if manager has not been initialized yet
 func GetManager() *manager {
+	getManagerLock.Lock()
+	defer getManagerLock.Unlock()
 	if managerInstance != nil {
 		return managerInstance
 	}
 	return nil
+}
+
+func (m *manager) Reset() {
+	getManagerLock.Lock()
+	defer getManagerLock.Unlock()
+	managerInstance = nil
 }
 
 func (m *manager) RegisterClassifierMethod(react ReactToNotification) {


### PR DESCRIPTION
When the sveltos-agent runs in the management cluster, it receives the managed cluster's kubeconfig from a Secret. These kubeconfigs can expire (e.g., GKE tokens have a maximum lifespan of 48 hours).

Sveltos includes a mechanism to proactively renew these tokens. The SveltosCluster controller can be configured to periodically refresh tokens before they expire, preventing disruptions.

However, prior to this change, the sveltos-agent, when deployed in the management cluster, lacked the ability to retrieve an updated kubeconfig. Consequently, upon kubeconfig expiration, the agent encountered numerous authorization errors, effectively ceasing operation.

This pull request addresses this issue by implementing a mechanism to detect kubeconfig expiration. Upon detection, the sveltos-agent retrieves a fresh, valid kubeconfig. This triggers a restart of the controller-runtime manager (and all associated controllers) as well as the evaluation manager, ensuring continued operation.

Fixes #336 
